### PR TITLE
Parent id fix

### DIFF
--- a/Web.Api/Controllers/TaskController.cs
+++ b/Web.Api/Controllers/TaskController.cs
@@ -51,7 +51,7 @@ namespace Web.Api.Controllers
                     Priority = taskItem.Priority,
                     CreatedDate = taskItem.CreatedDate,
                     CreatedUserId = taskItem.CreatedUserId,
-                    ParentId = taskItem.SubTaskSubTaskItems.SingleOrDefault()?.TaskItemId,
+                    ParentTaskId = taskItem.SubTaskSubTaskItems.SingleOrDefault()?.TaskItemId,
                     Notes = taskItem.TaskItemNotes.Select                            //within the TaskDto create a new List of Notes that grabs TaskItemNotes and set their properties
                         (note => new NoteDto                                         //create new instance of NoteDto
                         {
@@ -516,8 +516,10 @@ namespace Web.Api.Controllers
                 }
 
                 //subtask creation if ParentId is provided
-                if (updateTaskDto.ParentTaskId.HasValue)
-                {
+                if (updateTaskDto.ParentTaskId.HasValue) {
+                    SubTask temp = taskItem.SubTaskSubTaskItems.First();
+                    _unitOfWork.TaskItem.DeleteSubTask(temp);
+
                     SubTask? subTask = new()
                     {
                         TaskItemId = updateTaskDto.ParentTaskId.Value,
@@ -526,14 +528,14 @@ namespace Web.Api.Controllers
                         CreatedUserId = userId
                     };
                     taskItem.SubTaskSubTaskItems.Add(subTask);
+                    await _unitOfWork.SaveChangesAsync();
                 }
-                await _unitOfWork.SaveChangesAsync();
+                
 
                 if (updateTaskDto.Title != null && updateTaskDto.Priority >= 0)
                 {
                     taskItem.Title = updateTaskDto.Title;
                     taskItem.Priority = updateTaskDto.Priority;
-                    //taskItem.DueDate = updateTaskDto.DueDate.Value;
                     if (updateTaskDto.DueDate != null)
                     {
                         taskItem.DueDate = updateTaskDto.DueDate.Value;

--- a/Web.Api/Controllers/TaskController.cs
+++ b/Web.Api/Controllers/TaskController.cs
@@ -517,13 +517,14 @@ namespace Web.Api.Controllers
 
                 //subtask creation if ParentId is provided
                 if (updateTaskDto.ParentTaskId.HasValue) {
+                    //remove old parent task relationship if there exists one
                     SubTask? temp = taskItem.SubTaskSubTaskItems.FirstOrDefault();
                     if (temp != null)
                     {
                         await _unitOfWork.TaskItem.DeleteSubTask(temp);
                     }
                     
-
+                    //create relationship with provided parent task
                     SubTask? subTask = new()
                     {
                         TaskItemId = updateTaskDto.ParentTaskId.Value,

--- a/Web.Api/Controllers/TaskController.cs
+++ b/Web.Api/Controllers/TaskController.cs
@@ -518,7 +518,7 @@ namespace Web.Api.Controllers
                 //subtask creation if ParentId is provided
                 if (updateTaskDto.ParentTaskId.HasValue) {
                     SubTask temp = taskItem.SubTaskSubTaskItems.First();
-                    _unitOfWork.TaskItem.DeleteSubTask(temp);
+                    await _unitOfWork.TaskItem.DeleteSubTask(temp);
 
                     SubTask? subTask = new()
                     {

--- a/Web.Api/Controllers/TaskController.cs
+++ b/Web.Api/Controllers/TaskController.cs
@@ -517,8 +517,12 @@ namespace Web.Api.Controllers
 
                 //subtask creation if ParentId is provided
                 if (updateTaskDto.ParentTaskId.HasValue) {
-                    SubTask temp = taskItem.SubTaskSubTaskItems.First();
-                    await _unitOfWork.TaskItem.DeleteSubTask(temp);
+                    SubTask? temp = taskItem.SubTaskSubTaskItems.FirstOrDefault();
+                    if (temp != null)
+                    {
+                        await _unitOfWork.TaskItem.DeleteSubTask(temp);
+                    }
+                    
 
                     SubTask? subTask = new()
                     {
@@ -532,7 +536,7 @@ namespace Web.Api.Controllers
                 }
                 
 
-                if (updateTaskDto.Title != null && updateTaskDto.Priority >= 0)
+                if (updateTaskDto.Title != null && updateTaskDto.Priority >= 0 )
                 {
                     taskItem.Title = updateTaskDto.Title;
                     taskItem.Priority = updateTaskDto.Priority;

--- a/Web.Api/Controllers/TaskController.cs
+++ b/Web.Api/Controllers/TaskController.cs
@@ -498,56 +498,62 @@ namespace Web.Api.Controllers
                     return StatusCode(403);
                 }
 
-            TaskItem? taskItem = await _unitOfWork.TaskItem.GetTaskByIdAsync(taskId, userId);
-            if (taskItem is null)
-            {
-            _logger.LogWarning($"TaskId {taskId} not found for UserId {userId}");
-            return NotFound(taskId);
-            }
-
-            //check if parent task exists
-            if (updateTaskDto.ParentTaskId.HasValue)
-            {
-                TaskItem? parentTask = await _unitOfWork.TaskItem.GetTaskByIdAsync(updateTaskDto.ParentTaskId.Value, userId);
-                if (parentTask is null)
+                TaskItem? taskItem = await _unitOfWork.TaskItem.GetTaskByIdAsync(taskId, userId);
+                if (taskItem is null)
                 {
-                    return NotFound(updateTaskDto.ParentTaskId);
+                    _logger.LogWarning($"TaskId {taskId} not found for UserId {userId}");
+                    return NotFound(taskId);
                 }
-            }
 
-            //subtask creation if ParentId is provided
-            if (updateTaskDto.ParentTaskId.HasValue)
-            {
-                SubTask? subTask = new()
+                //check if parent task exists
+                if (updateTaskDto.ParentTaskId.HasValue)
                 {
-                    TaskItemId = updateTaskDto.ParentTaskId.Value,
-                    SubTaskItemId = taskItem.Id,
-                    CreatedDate = DateTime.Now,
-                    CreatedUserId = userId
-                };
-                taskItem.SubTaskSubTaskItems.Add(subTask);
-            }
-            await _unitOfWork.SaveChangesAsync();
+                    TaskItem? parentTask = await _unitOfWork.TaskItem.GetTaskByIdAsync(updateTaskDto.ParentTaskId.Value, userId);
+                    if (parentTask is null)
+                    {
+                        return NotFound(updateTaskDto.ParentTaskId);
+                    }
+                }
 
-                if (updateTaskDto.Title != null &&
-                    updateTaskDto.DueDate.HasValue &&
-                    updateTaskDto.Priority >= 0)
+                //subtask creation if ParentId is provided
+                if (updateTaskDto.ParentTaskId.HasValue)
+                {
+                    SubTask? subTask = new()
+                    {
+                        TaskItemId = updateTaskDto.ParentTaskId.Value,
+                        SubTaskItemId = taskItem.Id,
+                        CreatedDate = DateTime.Now,
+                        CreatedUserId = userId
+                    };
+                    taskItem.SubTaskSubTaskItems.Add(subTask);
+                }
+                await _unitOfWork.SaveChangesAsync();
+
+                if (updateTaskDto.Title != null && updateTaskDto.Priority >= 0)
                 {
                     taskItem.Title = updateTaskDto.Title;
-                    taskItem.DueDate = updateTaskDto.DueDate.Value;
                     taskItem.Priority = updateTaskDto.Priority;
+                    //taskItem.DueDate = updateTaskDto.DueDate.Value;
+                    if (updateTaskDto.DueDate != null)
+                    {
+                        taskItem.DueDate = updateTaskDto.DueDate.Value;
+                    }
+                    else
+                    {
+                        taskItem.DueDate = null;
+                    }
                 }
                 await _unitOfWork.SaveChangesAsync();
                 _logger.LogInformation($"Task Edit is Successfull for userId {userId}");
 
-            //Response DTO
-            TaskDto editTaskResult = new TaskDto
-            {
-                Id = taskItem.Id,
-                Title = taskItem.Title,
-                DueDate = taskItem.DueDate,
-                Priority = taskItem.Priority,
-                ParentTaskId = taskItem.SubTaskSubTaskItems.FirstOrDefault()?.TaskItemId,
+                //Response DTO
+                TaskDto editTaskResult = new TaskDto
+                {
+                    Id = taskItem.Id,
+                    Title = taskItem.Title,
+                    DueDate = taskItem.DueDate,
+                    Priority = taskItem.Priority,
+                    ParentTaskId = taskItem.SubTaskSubTaskItems.FirstOrDefault()?.TaskItemId,
 
                     Notes = taskItem.TaskItemNotes.Select(n => new NoteDto
                     {

--- a/Web.Api/Dto/Response/TaskDto.cs
+++ b/Web.Api/Dto/Response/TaskDto.cs
@@ -14,6 +14,6 @@ namespace Web.Api.Dto.Response
         public List<StatusDto> StatusHistories { get; set; } = [];
         public DateTime CreatedDate { get; set; }
         public Guid CreatedUserId { get; set; }
-        public Guid? ParentId { get; set; }
+        //public Guid? ParentId { get; set; }
     }
 }

--- a/Web.Api/Persistence/Repositories/TaskItemRepo.cs
+++ b/Web.Api/Persistence/Repositories/TaskItemRepo.cs
@@ -25,6 +25,7 @@ namespace Web.Api.Persistence.Repositories
             return await _context.TaskItems
                 .Include(item => item.TaskItemNotes)
                 .Include(item => item.SubTaskSubTaskItems)
+                .Include(item => item.SubTaskTaskItems)
                 .Include(history => history.TaskItemStatusHistories)
                     .ThenInclude(stat => stat.Status)
                  .Include(e => e.TaskWithinLists)
@@ -74,6 +75,11 @@ namespace Web.Api.Persistence.Repositories
             }
 
             _context.Remove(taskselection);
+        }
+
+        public async Task DeleteSubTask(SubTask subTaskItem)
+        {
+            _context.Remove(subTaskItem);
         }
 
         public void DeleteTaskWithinLists(TaskWithinList taskWithinLists)


### PR DESCRIPTION
Fixed:
- allows nullable due dates when editing a task.
- removed all instances of the parentId property to make the whole program consistent with the parentTaskId property instead.
- Updated the editTaskById so that whenever a user requests to change the parent task, the previous parent task relationship is severed, and a new one is created and updated.