### PR TITLE
Password Reset

### DIFF
--- a/Web.Api/Controllers/UserController.cs
+++ b/Web.Api/Controllers/UserController.cs
@@ -81,24 +81,82 @@ namespace Web.Api.Controllers
                 if (userLogin is null)
                 {
                     _logger.LogWarning($"Invalid user email: {userLoginDto.Email}");
-                    return BadRequest("Invalid email.");
+                    return BadRequest("Invalid email, try again.");
                 }
 
-                Password databasePsw = await _unitOfWork.User.GetPasswordByIdAsync(userLogin.Id);
+                Password? databasePsw = (await _unitOfWork.User.GetPasswordsByIdAsync(userLogin.Id)).FirstOrDefault();
+                if(databasePsw is null)
+                {
+                    _logger.LogWarning($"No password exists for user: {userLogin.Id} with the email: {userLoginDto.Email}");
+                    return BadRequest("No password exists for user.");
+                }
+
                 PasswordHasher hash = new PasswordHasher();
                 byte[] hashedPsw = hash.GenerateHash(userLoginDto.Password, databasePsw.Salt);
-                if (hashedPsw.SequenceEqual(databasePsw.PasswordHash))
-                {
-                    _logger.LogInformation($"User has logged in successfully: {userLoginDto.Email}");
-                    _logger.LogInformation($"Returning user login id {userLogin.Id}");
-                    return Ok(userLogin.Id);                                     // return the registered GUID Id of that user
-                }
-                else
+                if (!hashedPsw.SequenceEqual(databasePsw.PasswordHash))
                 {
                     _logger.LogWarning($"Invalid password for user with email: {userLoginDto.Email}");
-                    return BadRequest("Invalid password");
+                    return Unauthorized("Invalid password, try again");
                 }
 
+                //checking if password creation date is > 60 days ago
+                _logger.LogInformation($"Checking password expiration");
+                if (DateTime.Now - databasePsw.CreatedDate > TimeSpan.FromDays(60)) {
+                    _logger.LogInformation("Password creation date has exceeded 60 days");
+                    return Unauthorized("Password has expired, please reset the password.");
+                }
+
+                _logger.LogInformation($"User has logged in successfully: {userLoginDto.Email}");
+                _logger.LogInformation($"Returning user login id {userLogin.Id}");
+                return Ok(userLogin.Id); // return the registered GUID Id of that user
+            }
+        }
+
+        [HttpPost("reset", Name = "ResetPassword")]
+        public async Task<ActionResult> ResetPassword(ResetPasswordDto resetPswDto)
+        {
+            using (_logger.BeginScope(new Dictionary<string, object> { ["TransactionId"] = HttpContext.TraceIdentifier, }))
+            {
+                _logger.LogInformation("Checking login info");
+                User? user = await _unitOfWork.User.GetUserByEmailAsync(resetPswDto.email);
+                if (user is null)
+                {
+                    _logger.LogWarning($"Invalid user email: {resetPswDto.email}");
+                    return BadRequest("Invalid email. Try again.");
+                }
+
+                _logger.LogInformation("Checking password");
+                Password? databasePsw = (await _unitOfWork.User.GetPasswordsByIdAsync(user.Id)).FirstOrDefault();
+                if (databasePsw is null)
+                {
+                    _logger.LogWarning($"No password exists for user: {user.Id} with the email: {resetPswDto.email}");
+                    return BadRequest("No password exists for user.");
+                }
+
+                //checking password
+                PasswordHasher hash = new PasswordHasher();
+                byte[] hashedOldPsw = hash.GenerateHash(resetPswDto.oldPassword, databasePsw.Salt);
+                if (!hashedOldPsw.SequenceEqual(databasePsw.PasswordHash))
+                {
+                    _logger.LogWarning($"Invalid password for user with email: {resetPswDto.email}");
+                    return Unauthorized("Invalid password");
+                }
+
+                //Email and password correct so we will create new password
+                _logger.LogInformation("Hashing new password");
+                string generatedSalt = hash.GenerateSalt();
+                byte[] hashedNewPassword = hash.GenerateHash(resetPswDto.newPassword, generatedSalt);
+                Password newPsw = new Password
+                {
+                    PasswordHash = hashedNewPassword,
+                    Salt = generatedSalt,
+                    CreatedDate = DateTime.Now,
+                    CreatedUserId = user.Id,
+                };
+                _logger.LogInformation("Created new password");
+                await _unitOfWork.User.CreatePasswordAsync(newPsw);
+                await _unitOfWork.SaveChangesAsync();
+                return Ok(user.Id);
             }
         }
     }

--- a/Web.Api/Dto/Request/ResetPasswordDto.cs
+++ b/Web.Api/Dto/Request/ResetPasswordDto.cs
@@ -1,0 +1,9 @@
+﻿namespace Web.Api.Dto.Request
+{
+    public class ResetPasswordDto
+    {
+        public string email { get; set; }
+        public string oldPassword { get; set; }
+        public string newPassword { get; set; }
+    }
+}

--- a/Web.Api/Persistence/Repositories/UserRepo.cs
+++ b/Web.Api/Persistence/Repositories/UserRepo.cs
@@ -38,12 +38,8 @@ namespace Web.Api.Persistence.Repositories
 
         public async Task<List<Password>> GetPasswordsByIdAsync(Guid userId)
         {
-            return await _context.Passwords.Where(ui => ui.CreatedUserId == userId).OrderByDescending(x => x.CreatedDate).ToListAsync();
-        }
 
-        public async Task CreatePasswordByIdAsync(Password password)
-        {
-            await _context.AddAsync(password);
+            return await _context.Passwords.Where(ui => ui.CreatedUserId == userId).OrderByDescending(x => x.CreatedDate).ToListAsync();
         }
 
         //method to check if user exists in db by Id

--- a/Web.Api/Persistence/Repositories/UserRepo.cs
+++ b/Web.Api/Persistence/Repositories/UserRepo.cs
@@ -36,9 +36,14 @@ namespace Web.Api.Persistence.Repositories
             return await _context.Users.FirstOrDefaultAsync(ui => ui.Id == userId);
         }
 
-        public async Task<Password> GetPasswordByIdAsync(Guid userId)
+        public async Task<List<Password>> GetPasswordsByIdAsync(Guid userId)
         {
-            return await _context.Passwords.SingleAsync(ui => ui.CreatedUserId == userId);
+            return await _context.Passwords.Where(ui => ui.CreatedUserId == userId).OrderByDescending(x => x.CreatedDate).ToListAsync();
+        }
+
+        public async Task CreatePasswordByIdAsync(Password password)
+        {
+            await _context.AddAsync(password);
         }
 
         //method to check if user exists in db by Id


### PR DESCRIPTION
Allows client to only login if the password is correct AND newer than 60 days.

Some things added:
-  returns error if no password is found for user email
- after email and password is checked to exist and be correct according to db data, it checks if the creation date is not older than 60 days.
- created a reset password endpoint that checks if the credentials (email and password) are correct, and if they are, a new password is created from user info.
- reset password dto
- updated get password repo method to return all passwords from decreasing creation date
- created an addPassword repo method